### PR TITLE
Add padding to final sides of grid layouts

### DIFF
--- a/src/main/java/heronarts/glx/ui/UI2dContainer.java
+++ b/src/main/java/heronarts/glx/ui/UI2dContainer.java
@@ -228,7 +228,7 @@ public class UI2dContainer extends UI2dComponent implements UIContainer, Iterabl
           y += component.topMargin + component.getHeight() + component.bottomMargin + this.childSpacingY;
         }
       }
-      setContentWidth(Math.max(this.minWidth, x + w));
+      setContentWidth(Math.max(this.minWidth, x + w + this.rightPadding));
     } else if (this.layout == Layout.HORIZONTAL_GRID) {
       float x = this.leftPadding;
       float y = this.topPadding;
@@ -246,7 +246,7 @@ public class UI2dContainer extends UI2dComponent implements UIContainer, Iterabl
           x += component.leftMargin + component.getWidth() + component.rightMargin + this.childSpacingX;
         }
       }
-      setContentHeight(Math.max(this.minHeight, y + h));
+      setContentHeight(Math.max(this.minHeight, y + h + this.bottomPadding));
     }
   }
 


### PR DESCRIPTION
Bug fix.  Width of VERTICAL_GRID content should include rightPadding and height of HORIZONTAL_GRID content should include bottomPadding.  Prior to this content was rendering with padding on only 3 sides.