### PR TITLE
Fix Maven build out of box by avoiding error on JAVA_HOME

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,7 @@
                     <doctitle>GLX API Specification</doctitle>
                     <version>false</version>
                     <windowtitle>GLX API</windowtitle>
+                    <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Same fix as LX, after this Run As > Maven build... > clean package runs without error out of box. 