### PR TITLE
Add amd64 and aarch64 profiles for linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,30 @@
     
     <profiles>
 		<profile>
+			<id>lwjgl-natives-linux-amd64</id>
+			<activation>
+				<os>
+					<family>unix</family>
+					<arch>amd64</arch>
+				</os>
+			</activation>
+			<properties>
+				<lwjgl.natives>natives-linux</lwjgl.natives>
+			</properties>
+		</profile>
+		<profile>
+			<id>lwjgl-natives-linux-aarch64</id>
+			<activation>
+				<os>
+					<family>unix</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<lwjgl.natives>natives-linux-arm64</lwjgl.natives>
+			</properties>
+		</profile>
+		<profile>
 			<id>lwjgl-natives-macos-x86_64</id>
 			<activation>
 				<os>


### PR DESCRIPTION
In order to start the lwjgl work we need to add linux profiles for
various family/architecture combinations.
