### PR TITLE
For discussion: Alignments

### DIFF
--- a/src/main/java/heronarts/glx/ui/UI2dComponent.java
+++ b/src/main/java/heronarts/glx/ui/UI2dComponent.java
@@ -629,6 +629,27 @@ public abstract class UI2dComponent extends UIObject {
   }
 
   public UI2dComponent setHAlign(HAlign hAlign) {
+    return setHAlign(hAlign, false);
+  }
+
+  public UI2dComponent setHAlign(HAlign hAlign, boolean setTextAlign) {
+    if (setTextAlign) {
+      switch (hAlign) {
+      case LEFT:
+        setTextAlignment(VGraphics.Align.LEFT);
+        break;
+      case FILL:
+      case CENTER:
+        setTextAlignment(VGraphics.Align.CENTER);
+        break;
+      case RIGHT:
+        setTextAlignment(VGraphics.Align.RIGHT);
+        break;
+      case DEFAULT:
+      default:
+        break;
+      }
+    }
     return setAlign(hAlign, this.vAlign);
   }
 

--- a/src/main/java/heronarts/glx/ui/UI2dComponent.java
+++ b/src/main/java/heronarts/glx/ui/UI2dComponent.java
@@ -65,6 +65,32 @@ public abstract class UI2dComponent extends UIObject {
 
   protected final Scissor scissor = new Scissor();
 
+  public static enum HAlign {
+    DEFAULT,
+    LEFT,
+    CENTER,
+    RIGHT,
+    FILL;
+    // TODO: add enum value for Fixed/Absolute? For children overriding a container's content alignment.
+
+    public HAlign or(HAlign other) {
+      return this == DEFAULT ? other : this;
+    }
+  }
+
+  public static enum VAlign {
+    DEFAULT,
+    TOP,
+    MIDDLE,
+    BOTTOM,
+    FILL;
+    // TODO: add enum value for Fixed/Absolute? For children overriding a container's content alignment.
+
+    public VAlign or(VAlign other) {
+      return this == DEFAULT ? other : this;
+    }
+  }
+
   /**
    * Position of the object, relative to parent, top left corner
    */
@@ -90,6 +116,22 @@ public abstract class UI2dComponent extends UIObject {
     marginRight = 0,
     marginBottom = 0,
     marginLeft = 0;
+
+  protected HAlign hAlign = HAlign.DEFAULT;
+
+  protected VAlign vAlign = VAlign.DEFAULT;
+
+  /**
+   * When horizontal alignment is FILL, the percentage
+   * of available space in parent.
+   */
+  private float hFillPercent = 100f;
+
+  /**
+   * When vertical alignment is FILL, the percentage
+   * of available space in parent.
+   */
+  private float vFillPercent = 100f;
 
   float scrollX = 0;
 
@@ -575,6 +617,56 @@ public abstract class UI2dComponent extends UIObject {
     if (reflow && (this.parent instanceof UI2dContainer)) {
       ((UI2dContainer) this.parent).reflow();
     }
+    return this;
+  }
+
+  public HAlign getHAlign() {
+    return this.hAlign;
+  }
+
+  public VAlign getVAlign() {
+    return this.vAlign;
+  }
+
+  public UI2dComponent setHAlign(HAlign hAlign) {
+    return setAlign(hAlign, this.vAlign);
+  }
+
+  public UI2dComponent setVAlign(VAlign vAlign) {
+    return setAlign(this.hAlign, vAlign);
+  }
+
+  public UI2dComponent setAlign(HAlign hAlign, VAlign vAlign) {
+    boolean reflow = false;
+    if (this.hAlign != hAlign) {
+      this.hAlign = hAlign;
+      reflow = true;
+    }
+    if (this.vAlign != vAlign) {
+      this.vAlign = vAlign;
+      reflow = true;
+    }
+    if (reflow && (this.parent instanceof UI2dContainer)) {
+      ((UI2dContainer) this.parent).reflow();
+    }
+    return this;
+  }
+
+  public float getHFillPercent() {
+    return this.hFillPercent;
+  }
+
+  public float getVFillPercent() {
+    return this.vFillPercent;
+  }
+
+  public UI2dComponent setHFillPercent(float hFillPercent) {
+    this.hFillPercent = LXUtils.maxf(0f, hFillPercent);
+    return this;
+  }
+
+  public UI2dComponent setVFillPercent(float vFillPercent) {
+    this.vFillPercent = LXUtils.maxf(0f, vFillPercent);
     return this;
   }
 


### PR DESCRIPTION
This is a snowball at the top of a big hill, so I'm not pushing it far before checking in to see if you're interested in the direction.

I've been building UI elements recently and would love to gain the efficiency of fill/stretch alignments.  Example use case: after adding a [newVerticalContainer] column, setting it to non-standard width 70, I'd rather not call `setWidth(70)` on every child.  Ideally it would look like:

```
// Use fill for secondary direction
UI2dContainer column = newVerticalContainer(70);
column.setContentHAlignm(HAlign.FILL);  // Default secondary alignment for children
column.addChild(newLabel("Autosized!"));
column.addChild(newKnob(param).setHAlign(HAlign.CENTER));  // Child HAlign takes priority
```

The `FillPercent` variables mimic the behavior I used on the TouchOSC project last winter.  It allows a child to say: Size me to X percent of the space remaining after fixed-width children are placed.  In a lot of cases this would be one child set to fill 100% of remaining space.  But in some cases such as transition controls I might do:
```
// Use fill for primary direction
transitionControlRow.setContentHAlign(FILL);
transitionControlRow.addChildren(
  newButton(enabled, 15),  // 15 pixels wide
  newDropDown(blendMode).setHFillPercent(70),
  newTimeBox(transitionTime).setHFillPercent(30)
);

```
