### PR TITLE
Make UI2dContainer.removeAllChildren thread safe

### DIFF
--- a/src/main/java/heronarts/glx/ui/UI2dContainer.java
+++ b/src/main/java/heronarts/glx/ui/UI2dContainer.java
@@ -504,13 +504,13 @@ public class UI2dContainer extends UI2dComponent implements UIContainer, Iterabl
 
   public UI2dContainer removeAllChildren(boolean dispose) {
     UI2dContainer contentTarget = getContentTarget();
-    for (UIObject child : contentTarget.mutableChildren) {
-      ((UI2dComponent) child).parent = null;
+    for (int i = contentTarget.mutableChildren.size() - 1; i >= 0; i--) {
+      UI2dComponent child = (UI2dComponent) this.contentTarget.mutableChildren.get(i);
+      child.removeFromContainer(false);
       if (dispose) {
         child.dispose();
       }
     }
-    contentTarget.mutableChildren.clear();
     reflow();
     return this;
   }


### PR DESCRIPTION
Looks like `UIObject.mutableChildren` is set up to be thread safe as a `CopyOnWriteArrayList<>`.  But `UI2dContainer.removeAllChildren()` seems to not take advantage, it disposes of each child and then clears the collection.  If you call it from an engine thread parameter listener you get a race condition with the UI thread draw loop.

Don't know if this is the solution you would want but tossing it up as an option.
