### PR TITLE
Avoid background rendering outside of border, especially on rounded corners

### DIFF
--- a/src/main/java/heronarts/glx/ui/UI2dComponent.java
+++ b/src/main/java/heronarts/glx/ui/UI2dComponent.java
@@ -1711,8 +1711,9 @@ public abstract class UI2dComponent extends UIObject {
     }
 
     if (ownBackground) {
+      int borderWeight = this.hasBorder ? this.borderWeight : 0;
       vg.beginPath();
-      vgRoundedRect(vg);
+      vgRoundedRect(vg, borderWeight * .5f, borderWeight * .5f, this.width - borderWeight, this.height - borderWeight);
       vg.fillColor((this.hasFocus && this.hasFocusBackground) ? this.focusBackgroundColor : this.backgroundColor);
       vg.fill();
     }


### PR DESCRIPTION
There was a visual artifact on the corners of components with rounded borders.  It was visible at 100% zoom but more so at higher zoom.  As examples, the fixture.enabled toggle and effect.enabled toggle:

Before:
![image](https://github.com/user-attachments/assets/8f72958f-9dd8-44a5-9d7a-690280982c9d) ![image](https://github.com/user-attachments/assets/a31d3fd8-a7fa-4b8e-b868-a5248bcef7f4)

This looks like the culprit.  The roundedRect of the border was smaller [by amount `borderSize`] than the roundedRect of the background, to compensate for the stroke width, but creating a path difference on the corner.  The fix here draws the background to the center of the border rather than the outer edges.

After:
![image](https://github.com/user-attachments/assets/81af1643-5ded-49c2-893f-eee6d8df848e) ![image](https://github.com/user-attachments/assets/9cc16564-d27a-46a8-8856-e05fc60ab22e)

This might be a slight improvement on straight edges too.  At intermediate zooms it looks like there was an anti-aliasing glow of the background color shining outside of the border:
<img width="537" alt="image" src="https://github.com/user-attachments/assets/f63e474a-e117-4283-b0d0-8c7d0a250fc2">






