### PR TITLE
ChildSpacing accessors

### DIFF
--- a/src/main/java/heronarts/glx/ui/UI2dContainer.java
+++ b/src/main/java/heronarts/glx/ui/UI2dContainer.java
@@ -259,6 +259,14 @@ public class UI2dContainer extends UI2dComponent implements UIContainer, Iterabl
     return this.childSpacingY;
   }
 
+  protected float getLocalChildSpacingX() {
+    return this.childSpacingX;
+  }
+
+  protected float getLocalChildSpacingY() {
+    return this.childSpacingY;
+  }
+
   public UI2dContainer setMinWidth(float minWidth) {
     if (this.contentTarget.minWidth != minWidth) {
       this.contentTarget.minWidth = minWidth;

--- a/src/main/java/heronarts/glx/ui/UI2dContainer.java
+++ b/src/main/java/heronarts/glx/ui/UI2dContainer.java
@@ -217,6 +217,20 @@ public class UI2dContainer extends UI2dComponent implements UIContainer, Iterabl
     return this;
   }
 
+  public float getChildSpacingX() {
+    if (this.contentTarget != this) {
+      return this.contentTarget.getChildSpacingX();
+    }
+    return this.childSpacingX;
+  }
+
+  public float getChildSpacingY() {
+    if (this.contentTarget != this) {
+      return this.contentTarget.getChildSpacingY();
+    }
+    return this.childSpacingY;
+  }
+
   public UI2dContainer setMinWidth(float minWidth) {
     if (this.contentTarget.minWidth != minWidth) {
       this.contentTarget.minWidth = minWidth;

--- a/src/main/java/heronarts/glx/ui/UI2dContainer.java
+++ b/src/main/java/heronarts/glx/ui/UI2dContainer.java
@@ -208,11 +208,39 @@ public class UI2dContainer extends UI2dComponent implements UIContainer, Iterabl
     return setChildSpacing(childSpacing, childSpacing);
   }
 
-  public UI2dContainer setChildSpacing(float childSpacingY, float childSpacingX) {
-    if ((this.contentTarget.childSpacingX != childSpacingX) || (this.contentTarget.childSpacingY != childSpacingY)) {
-      this.contentTarget.childSpacingX = childSpacingX;
-      this.contentTarget.childSpacingY = childSpacingY;
-      this.contentTarget.reflow();
+  public UI2dContainer setChildSpacingX(float childSpacingX) {
+    if (this.contentTarget != this) {
+      this.contentTarget.setChildSpacingX(childSpacingX);
+    } else {
+      if (this.childSpacingX != childSpacingX) {
+        this.childSpacingX = childSpacingX;
+        reflow();
+      }
+    }
+    return this;
+  }
+
+  public UI2dContainer setChildSpacingY(float childSpacingY) {
+    if (this.contentTarget != this) {
+      this.contentTarget.setChildSpacingY(childSpacingY);
+    } else {
+      if (this.childSpacingY != childSpacingY) {
+        this.childSpacingY = childSpacingY;
+        reflow();
+      }
+    }
+    return this;
+  }
+
+  public UI2dContainer setChildSpacing(float childSpacingX, float childSpacingY) {
+    if (this.contentTarget != this) {
+      this.contentTarget.setChildSpacing(childSpacingX, childSpacingY);
+    } else {
+      if ((this.childSpacingX != childSpacingX) || (this.childSpacingY != childSpacingY)) {
+        this.childSpacingX = childSpacingX;
+        this.childSpacingY = childSpacingY;
+        reflow();
+      }
     }
     return this;
   }


### PR DESCRIPTION
Currently the `childSpacing` fields on `UI2dContainer` are private.  I would like to extend a `UI2dContainer` and perform a custom layout in the `onReflow()` method, making use of the `childSpacingX/Y` values.

My default inclination was to return the `contentTarget`'s values, for consistency with the `set` methods.  Reasoning that something could call `setChildSpacing(value)` and expect to get the same value returned from `getChildSpacingX()`.  However this is currently *not* how `setPadding` and `getPadding` behave.  `SetPadding()` stores the values on `contentTarget` but `getPadding` returns values from `this`.

It would be a source of confusion for the `get`/`set` pairs on `childSpacing` and `padding` to have different behaviors.  They should be made consistent.  Reasoning some more...

1.  For the use case of `subclass.reflow()` methods, it's actually critical to retrieve the local value.  ContentTarget will be doing its own reflow so we don't need to use the contentTarget's value.  Local values have utility for top-level layout.
2. For public (not subclass) use, it would make sense for a `get()` method to return the same value that was previously passed to a `set()` method.

I'm thinking there should be two pairs of `get()` methods, a `protected` version that returns the local value, and a `public` version that returns the `contentTarget`'s value.  If this seems right, any thoughts on a naming scheme?  Although methods that defer to contentTarget tend to have "Content" in the name, this style of somewhat-invisible redirect may make more sense to rename the protected version.  Such as `protected UI2dContainer getLocalChildSpacingX()`. _*Edit: pushed this change._

A related comment: the setPadding() and setChildSpacing() methods use java's class-level access control to set values on contentTarget's private fields.  This looks fragile if someone tried to build nested subcontainers, e.g. if this.contentTarget had its *own* independent contentTarget.  Wonder about changing this to be more resilient with a recursive call... _*Edit: pushed a change to this PR with a modified setChildSpacing(X, Y) as an example._
