### PR TITLE
Fix integer division of icon size

### DIFF
--- a/src/main/java/heronarts/glx/ui/component/UIButton.java
+++ b/src/main/java/heronarts/glx/ui/component/UIButton.java
@@ -660,10 +660,10 @@ public class UIButton extends UIParameterComponent implements UIControlTarget, U
 
     if (icon != null) {
       final UIColor iconColor = _getIconColor(ui);
-      final float iconX = this.width/2 - icon.width/2 + this.iconOffsetX;
+      final float iconX = this.width/2 - icon.width/2f + this.iconOffsetX;
       icon.setTint(iconColor);
       vg.beginPath();
-      vg.image(icon, iconX, this.height/2 - icon.height/2 + this.iconOffsetY);
+      vg.image(icon, iconX, this.height/2 - icon.height/2f + this.iconOffsetY);
       vg.fill();
       icon.noTint();
 

--- a/src/main/java/heronarts/glx/ui/component/UIContextButton.java
+++ b/src/main/java/heronarts/glx/ui/component/UIContextButton.java
@@ -169,8 +169,8 @@ public class UIContextButton extends UI2dComponent implements UIFocus {
       vg.beginPath();
       vg.image(
         this.icon,
-        this.iconOffsetX + this.width/2 - this.icon.width/2,
-        this.iconOffsetY + this.height/2 - this.icon.height/2
+        this.iconOffsetX + this.width/2 - this.icon.width/2f,
+        this.iconOffsetY + this.height/2 - this.icon.height/2f
       );
       vg.fill();
       this.icon.noTint();


### PR DESCRIPTION
Minor UI tweak.  Now dividing icon's integer width and height by `2f` instead of `2` to avoid rounding.

Confirmed the placement of midi keyboard icon still looks correct after this change, since it uses -0.5 y offset.